### PR TITLE
Added line to ci.yml to install mkdocs-jupyter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,5 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install mkdocs-rtd-dropdown
+      - run: pip install mkdocs-jupyter
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
The workflow was missing a line needed to install mkdocs-jupyter, causing the deployment to fail.