### PR TITLE
WV-2159 & WV-2160

### DIFF
--- a/docs/javascript/components.js
+++ b/docs/javascript/components.js
@@ -52,6 +52,7 @@ Vue.component('layer-table', {
   },
   data: function () {
     const { layers } = this.measurement;
+    console.log(layers);
     const defaultRenderer = {
       props: ['layer', 'property', 'url'],
       template: `<span> {{ layer[property] }} </span>`
@@ -237,6 +238,7 @@ Vue.component('layer-table', {
       const layerString = layers.join(',');
       const baseUrl = `https://worldview.earthdata.nasa.gov/?l=${layerString}`
       const params = startDate ? `&t=${date}` : ``
+      console.log(baseUrl + params);
       return baseUrl + params;
     } 
   },

--- a/docs/javascript/components.js
+++ b/docs/javascript/components.js
@@ -52,7 +52,6 @@ Vue.component('layer-table', {
   },
   data: function () {
     const { layers } = this.measurement;
-    console.log(layers);
     const defaultRenderer = {
       props: ['layer', 'property', 'url'],
       template: `<span> {{ layer[property] }} </span>`
@@ -224,6 +223,22 @@ Vue.component('layer-table', {
         newDate.setDate(newDate.getDate() + days);
         return newDate;
       }
+      const getProjectionParam = (projections) => {
+        const isGeographic = projections.includes("geographic");
+        const isArctic = projections.includes("arctic");
+        const isAntarctic = projections.includes("antarctic");
+
+        switch (true) {
+          case isGeographic:
+            return "";
+          case isArctic:
+            return "&p=arctic";
+          case isAntarctic:
+            return "&p=antarctic";
+          default:
+            break;
+        }
+      }
       if (startDate) {
         const newStartDate = addDays(startDate, 1);
         date = newStartDate.toISOString().split('T')[0]
@@ -237,9 +252,9 @@ Vue.component('layer-table', {
       ]
       const layerString = layers.join(',');
       const baseUrl = `https://worldview.earthdata.nasa.gov/?l=${layerString}`
+      const projectionParam = getProjectionParam(layer.projections);
       const params = startDate ? `&t=${date}` : ``
-      console.log(baseUrl + params);
-      return baseUrl + params;
+      return baseUrl + params + projectionParam;
     } 
   },
   mounted: function () {

--- a/docs/javascript/imagery-products.js
+++ b/docs/javascript/imagery-products.js
@@ -38,7 +38,7 @@ const getResolution = ({ projections, type }) => {
  */
 const getProjections = (layer) => {
   const projections = Object.keys(layer.projections);
-  if (layer.type !== "vector")
+  if (layer.type !== "vector" && layer.projections.hasOwnProperty("geographic"))
     projections.unshift("web mercator");
   return projections;
 }


### PR DESCRIPTION
# Issues:
Some layers are only available in polar projections but the URL on the Visualization Product Catalog page directs the user to the geographic projection. 

Some layers are only available in polar projections but incorrectly include "web mercator" in the layer catalog.

Ice Velocity (Antarctica) & Ice Velocity (Greenland) are examples of both of the above behaviors.

# To Test:

- git checkout wv-2159
- mkdocs serve
- Navigate to "Available Visualizations"
- Scroll to & expand "Ice Velocity (Antarctica)"
- Confirm "Web Mercator" is NOT listed in the Projection(s) column
- Click the URL in the Name/Identifier column & confirm it loads in the Antarctic projection

