### PR TITLE
WV-2636: Lightning layers listed Temporal Range is incorrect

### DIFF
--- a/docs/javascript/imagery-products.js
+++ b/docs/javascript/imagery-products.js
@@ -8,9 +8,10 @@ const getDate = (layer, key) => {
   if (!layer[key]) {
     return key === 'endDate' && layer['startDate'] ? 'Present' : '';
   }
-  const { period, inactive } = layer;
+  const { period, ongoing } = layer;
   const date = period === 'subdaily' ? layer[key] : layer[key].split('T')[0];
-  return (key === 'endDate' && !inactive) ? 'Present' : date;
+
+  return (key === 'endDate' && ongoing) ? 'Present' : date;
 }
 
 /**


### PR DESCRIPTION
# The problem
In the [product catalog](https://nasa-gibs.github.io/gibs-api-docs/available-visualizations/#visualization-product-catalog), the Temporal Range for the following layers indicates 1998-01-01 - Present but it should be 1998-01-01 - [End Date] since these products are no longer in operation.

- LIS_Very_High_Resolution_Lightning_Daily_Climatology_LIS_Mean_Flash_Rate
- LIS_Very_High_Resolution_Lightning_Seasonal_Climatology_LIS_Mean_Flash_Rate
- LIS_Very_High_Resolution_Lightning_Monthly_Climatology_LIS_Mean_Flash_Rate

The problem is not specific to these layers, as all layers in [production ](https://nasa-gibs.github.io/gibs-api-docs/available-visualizations/#visualization-product-catalog) are listed with an end date of "Present". Use these 3 layers as a guide but not an exhaustive list.

# To test

- git checkout wv-2636-incorrect-time-range
- Follow Readme to install mkdocs & serve the page locally

Check the layers:
- Find the layer(s) in the product list [on this page](http://127.0.0.1:8000/available-visualizations/)
- Click the link in the Name/Identifier column to open the layer in worldview
- Click the Info (View Description) icon for the layer & confirm the listed dates in Worldview match the dates listed in the product catalog.