### PR TITLE
WV-2161: Updating Catalog Table Headers

### DIFF
--- a/docs/javascript/components.js
+++ b/docs/javascript/components.js
@@ -98,6 +98,17 @@ Vue.component('layer-table', {
           renderer: defaultRenderer
         },
         {
+          title: 'Temporal Range',
+          property: 'temporalRange',
+          sortable: true,
+          sortFn: this.sortDate,
+          visible: (() => layers.some(({ startDate }) => startDate ))(),
+          renderer: {
+            ...defaultRenderer,
+            template: `<span> {{ layer.startDate }} - <br/> {{ layer.endDate }} </span>`
+          }
+        },
+        {
           title: `
             <span>
               Projection(s)
@@ -146,17 +157,6 @@ Vue.component('layer-table', {
           sortable: true,
           visible: (() => layers.some(({ format }) => format ))(),
           renderer: defaultRenderer
-        },
-        {
-          title: 'Temporal Range',
-          property: 'temporalRange',
-          sortable: true,
-          sortFn: this.sortDate,
-          visible: (() => layers.some(({ startDate }) => startDate ))(),
-          renderer: {
-            ...defaultRenderer,
-            template: `<span> {{ layer.startDate }} - <br/> {{ layer.endDate }} </span>`
-          }
         },
         {
           title: `

--- a/docs/javascript/imagery-products.js
+++ b/docs/javascript/imagery-products.js
@@ -65,7 +65,7 @@ const getProducts = (conceptIds) => {
 function formatLayers (layers) {
   Object.keys(layers).forEach(id => {
     const layer = layers[id];
-    const { period, title, layergroup } = layer;
+    const { layerPeriod: period, title, layergroup } = layer;
     const format = (layer.format || ' / ').split('/')[1];
     const [ platform, instrument ] = (layer.subtitle || ' / ').split('/');
     layers[id] = {


### PR DESCRIPTION
Some of the layers in the layer catalog were displaying 'daily' temporal periods which was misleading. This updates all layers to use the 'layerPeriod' property of the metadata in the period column of the layer catalog table. This means that 8-day products will display '8-day' in this column instead of 'Daily'. 

This also moves the temporal range column in the layer catalog column headers next to the period column. 

How to test:
1. Ensure that the necessary python dependencies from the readme are installed.
2. Open a terminal and `cd` into your repo. 
3. `mkdocs serve`
4. Open the available-visualizations page.
5. Find the 'Leaf Area Index' group and verify that the 'Period' column for each layer displays either '8-Day' or '4-Day'. 
6. Also verify that the 'Period' column and the 'Temporal Range' column are side by side. 