### PR TITLE
Enable search bar

### DIFF
--- a/docs/available-visualizations.md
+++ b/docs/available-visualizations.md
@@ -75,7 +75,7 @@ This interactive catalog provides the following information about each GIBS visu
         <sup>[3]</sup> NRT - Near Real-Time: The imagery product is generated within 3.5 hours of observation. STD - Standard: The imagery product is generated within 24 hours of observation.
       </p>
        <p id="footnote-4">
-        <sup>[4]</sup> When multiple data products are identified, the GIBS visualization product will provide users with a view of the “Best Available” data product.  See the <a href="../api-advanced-topics/#best-available-layers">Best Available Layers advanced topic</a> for more information on how this is determined.
+        <sup>[4]</sup> When multiple data products are identified, the GIBS visualization product will provide users with a view of the “Best Available” data product.  See the <a href="../access-advanced-topics/#best-available-layers">Best Available Layers advanced topic</a> for more information on how this is determined.
       </p>
 
     </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,3 +26,4 @@ markdown_extensions:
     - footnotes
 plugins:
     - mkdocs-jupyter
+    - search


### PR DESCRIPTION
The docs contain enough information, such that a search bar would be very convenient. Per https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/, this simply needs to be specifically enabled since a plugin is already used.

Also, a broken link is fixed.
