### PR TITLE
Update map-library-usage.md

### DIFF
--- a/docs/map-library-usage.md
+++ b/docs/map-library-usage.md
@@ -357,7 +357,9 @@ The projection string for the GIBS Antarctic projection is "+proj=stere +lat_0=-
 
 ```
 gdal_translate -of GTiff -outsize 980 940 -projwin 1520000 240000 2500000 -700000 GIBS_Terra_MODIS_Arctic.xml BarentsSea.tif
-"copy" GIBS_Arctic_3413.tif.aux.xml "to"  BarentsSea.tif.aux.xml
+```
+Then copy "GIBS_Arctic_3413.tif.aux.xml" to "BarentsSea.tif.aux.xml", followed by:
+```
 gdal_translate -of JPEG BarentsSea.tif BarentsSea.jpg
 ```
 

--- a/docs/map-library-usage.md
+++ b/docs/map-library-usage.md
@@ -353,13 +353,10 @@ gdal_translate -of JPEG BarentsSea.tif BarentsSea.jpg
 
 The projection string for the GIBS Antarctic projection is "+proj=stere +lat_0=-90 +lat_ts=-71 +lon_0=0 +k=1 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs". Here are the links for the [Arctic](http://spatialreference.org/ref/epsg/3413/proj4/){:target="_blank"} and [Antarctic](http://spatialreference.org/ref/epsg/3031/proj4/){:target="_blank"} PROJ4 definitions. Some other workarounds are:
 
-* Use a ".aux.xml" file with the ".tif" file. Download the sample [Arctic](img/GIBS_Arctic_3413.tif.aux.xml){:target="_blank"} or [Antarctic](img/GIBS_Antarctic_3031.tif.aux.xml){:target="_blank"} XML file and rename it to match the GeoTIFF file.
+* Use a ".aux.xml" file with the ".tif" file. Download the sample [Arctic](img/GIBS_Arctic_3413.tif.aux.xml){:target="_blank"} or [Antarctic](img/GIBS_Antarctic_3031.tif.aux.xml){:target="_blank"} XML file and rename it to match the GeoTIFF file (copy "GIBS_Arctic_3413.tif.aux.xml" to "BarentsSea.tif.aux.xml").
 
 ```
 gdal_translate -of GTiff -outsize 980 940 -projwin 1520000 240000 2500000 -700000 GIBS_Terra_MODIS_Arctic.xml BarentsSea.tif
-```
-Then copy "GIBS_Arctic_3413.tif.aux.xml" to "BarentsSea.tif.aux.xml", followed by:
-```
 gdal_translate -of JPEG BarentsSea.tif BarentsSea.jpg
 ```
 


### PR DESCRIPTION
The original "copy" and "to" commands appeared to be part of the gdal_translate command, causing confusion. The calls were separated into separate steps for better readability.